### PR TITLE
chore(dagger): upgrade Dagger SDK to 0.19.11, refactor Docker build, add GHf merge rule, disable noArrayIndexKey lint

### DIFF
--- a/.ghf.ts
+++ b/.ghf.ts
@@ -2,4 +2,12 @@ import type { Config } from './.ghf.type'
 
 export default {
   extends: ['https://michaelmass.github.io/ghf/ghf.default.json'],
+  rules: [
+    {
+      type: 'merge',
+      content: '{"deno.enablePaths": ["dagger"]}',
+      path: '.vscode/settings.json',
+      mergeArrays: true,
+    }
+  ]
 } satisfies Config

--- a/Tiltfile
+++ b/Tiltfile
@@ -24,6 +24,10 @@ load(
 dotenv_watch()
 default_settings()
 
+local('deno run -A jsr:@michaelmass/ghf/cli type -o=.ghf.type.ts', quiet=True)
+local('deno run -A jsr:@michaelmass/ghf/cli apply', quiet=True)
+local('lefthook install', quiet=True)
+
 resource(
   name="test",
   cmd="dagger run deno run --no-lock --node-modules-dir=false -A ./dagger/test/index.ts",

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,7 @@
       "recommended": true,
       "suspicious": {
         "noExplicitAny": "error",
-        "noArrayIndexKey": "error",
+        "noArrayIndexKey": "off",
         "noConsole": "error"
       },
       "nursery": {

--- a/dagger/dagger.ts
+++ b/dagger/dagger.ts
@@ -1,1 +1,1 @@
-export * from 'npm:@dagger.io/dagger@0.19.9'
+export * from 'npm:@dagger.io/dagger@0.19.11'

--- a/dagger/docker.ts
+++ b/dagger/docker.ts
@@ -59,9 +59,8 @@ type BuildOptions = {
 export async function build({ client, dir = '.', dockerfile = 'Dockerfile', platform = 'linux/amd64' }: BuildOptions) {
   const directory = typeof dir === 'string' ? client.host().directory(dir) : dir
 
-  const container = await client
-    .container({ platform: platform as Platform })
-    .build(directory, { dockerfile })
+  const container = await directory
+    .dockerBuild({ dockerfile, platform: platform as Platform })
     .sync()
 
   return container


### PR DESCRIPTION
Add GHf merge rule, update Dagger version, adjust biome settings, improve Docker build workflow, and integrate GHf CLI commands.

**Overview of changes**
- **`.ghf.ts`**: Added a merge rule to inject Deno enable paths for the `dagger` project into VS Code settings, with array merging enabled.
- **`Tiltfile`**: Integrated GHf CLI commands to generate type definitions, apply configuration, and install lefthook hooks automatically.
- **`biome.json`**: Disabled the `noArrayIndexKey` rule to reduce false positives.
- **`dagger/dagger.ts`**: Updated the Dagger SDK version from `0.19.9` to `0.19.11`.
- **`dagger/docker.ts`**: Refactored Docker build logic to use `directory.dockerBuild` for a cleaner API and ensured synchronous execution.
- **`lefthook.yml`**: Added a placeholder for lefthook configuration (currently empty).